### PR TITLE
Make Utils.getSublocales work the way it does in ilib

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.1.3
+
+* Make Utils.getSublocales work the same way it did under ilib so that
+  variant locales are loaded properly.
+
 ### v1.1.2
 
 * This module is now a hybrid ESM/CommonJS package that works under node

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-common",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -122,7 +122,6 @@ export function getSublocales(locale) {
     if (lang) {
         ret.push(lang);
     }
-
     if (region) {
         ret.push('und-' + region);
     }
@@ -131,9 +130,11 @@ export function getSublocales(locale) {
         if (script) {
             ret.push(lang + '-' + script);
         }
-
         if (region) {
             ret.push(lang + '-' + region);
+        }
+        if (variant) {
+            ret.push(lang + '-' + variant);
         }
     }
 
@@ -145,11 +146,12 @@ export function getSublocales(locale) {
         if (script && region) {
             ret.push(lang + '-' + script + '-' + region);
         }
-
+        if (script && variant) {
+            ret.push(lang + '-' + script + '-' + variant);
+        }
         if (region && variant) {
             ret.push(lang + '-' + region + '-' + variant);
         }
-
         if (script && region && variant) {
             ret.push(lang + '-' + script + '-' + region + '-' + variant);
         }

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -423,14 +423,34 @@ export const testUtils = {
     testGetSublocalesWithVariant: function(test) {
         test.expect(1);
 
-        test.deepEqual(Utils.getSublocales("es-US-ASDF"), ["root", "es", "und-US", "es-US", "und-US-ASDF", "es-US-ASDF"]);
+        test.deepEqual(Utils.getSublocales("es-US-ASDF"), [
+            "root",
+            "es",
+            "und-US",
+            "es-US",
+            "es-ASDF",
+            "und-US-ASDF",
+            "es-US-ASDF"
+        ]);
         test.done();
     },
 
     testGetSublocalesWithScriptAndVariant: function(test) {
         test.expect(1);
 
-        test.deepEqual(Utils.getSublocales("zh-Hans-CN-ASDF"), ["root", "zh", "und-CN", "zh-Hans", "zh-CN", "und-CN-ASDF", "zh-Hans-CN", "zh-CN-ASDF", "zh-Hans-CN-ASDF"]);
+        test.deepEqual(Utils.getSublocales("zh-Hans-CN-ASDF"), [
+            "root",
+            "zh",
+            "und-CN",
+            "zh-Hans",
+            "zh-CN",
+            "zh-ASDF",
+            "und-CN-ASDF",
+            "zh-Hans-CN",
+            "zh-Hans-ASDF",
+            "zh-CN-ASDF",
+            "zh-Hans-CN-ASDF"
+        ]);
         test.done();
     },
 
@@ -767,7 +787,8 @@ export const testUtils = {
         let f = Utils.getLocFiles(locale, "localeinfo.json");
         let expected = [
             "localeinfo.json",
-            "en/localeinfo.json"
+            "en/localeinfo.json",
+            "en/govt/localeinfo.json"
         ];
         
         test.equal(f.length, expected.length);
@@ -829,7 +850,9 @@ export const testUtils = {
         let expected = [
             "localeinfo.json",
             "en/localeinfo.json",
-            "en/Latn/localeinfo.json"
+            "en/Latn/localeinfo.json",
+            "en/govt/localeinfo.json",
+            "en/Latn/govt/localeinfo.json"
         ];
         
         test.equal(f.length, expected.length);
@@ -846,6 +869,7 @@ export const testUtils = {
             "en/localeinfo.json",
             "und/US/localeinfo.json",
             "en/US/localeinfo.json",
+            "en/govt/localeinfo.json",
             "und/US/govt/localeinfo.json",
             "en/US/govt/localeinfo.json"
         ];
@@ -865,8 +889,10 @@ export const testUtils = {
             "und/US/localeinfo.json",
             "en/Latn/localeinfo.json",
             "en/US/localeinfo.json",
+            "en/govt/localeinfo.json",
             "und/US/govt/localeinfo.json",
             "en/Latn/US/localeinfo.json",
+            "en/Latn/govt/localeinfo.json",
             "en/US/govt/localeinfo.json",
             "en/Latn/US/govt/localeinfo.json"
         ];
@@ -899,8 +925,10 @@ export const testUtils = {
             "und/US/resources.json",
             "en/Latn/resources.json",
             "en/US/resources.json",
+            "en/govt/resources.json",
             "und/US/govt/resources.json",
             "en/Latn/US/resources.json",
+            "en/Latn/govt/resources.json",
             "en/US/govt/resources.json",
             "en/Latn/US/govt/resources.json"
         ];


### PR DESCRIPTION
- did not deal with the flavors/variants properly and returned different results from ilib
- now produces the same output as ilib